### PR TITLE
Fix audio previews on user pages

### DIFF
--- a/oga2/oga_theme.js
+++ b/oga2/oga_theme.js
@@ -41,13 +41,15 @@
       multiSelectToggle($(this));
     });
 
-    $('.content').delegate('.play-button', 'click', function() {
+    $('.content').delegate('.play-button', 'click', function(e) {
       $('.stop-button').trigger('click');
       playButton(this);
+      e.stopPropagation();
     });
 
-    $('.content').delegate('.stop-button', 'click', function() {
+    $('.content').delegate('.stop-button', 'click', function(e) {
       stopButton(this);
+      e.stopPropagation();
     });
 
     $('.content').delegate('.subtree-toggle', 'click', function() {


### PR DESCRIPTION
The play/stop button is inside multiple nested elements with the .content class, so it ends up immediately stopping the audio after starting it.